### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 license = "GPL-3.0-or-later"
 description = "A set of traits and utilities for streamlining CRUD boilerplate with sqlx and axum"
-repository = "https://www.github.com/zenlex/crustd"
+repository = "https://github.com/zenlex/crustd"
 
 [dependencies]
 async-trait = "0.1.80"


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96